### PR TITLE
Add support for environment based configuration.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
+
+/mtls-transmitter

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
 .PHONY: validate build
+IMAGE_NAME ?= crabtree/mtls-transmitter
+IMAGE_TAG ?= $(shell git rev-parse HEAD)
 
 validate: format
 	#==> Verify modules.
@@ -12,3 +14,7 @@ format:
 
 build:
 	go build -o mtls-transmitter ./cmd/transmitter
+
+image: validate
+	docker build -t $(IMAGE_NAME):$(IMAGE_TAG) -f Dockerfile .
+	docker tag $(IMAGE_NAME):$(IMAGE_TAG) $(IMAGE_NAME):latest

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,14 @@
+.PHONY: validate build
+
+validate: format
+	#==> Verify modules.
+	go mod verify
+	#==> It's worth running 'go test' to make sure things compile correctly.
+	go test -race ./...
+
+format:
+	#==> Verify and update formatting, don't forget to commit on changes.
+	go fmt ./...
+
+build:
+	go build -o mtls-transmitter ./cmd/transmitter

--- a/README.md
+++ b/README.md
@@ -15,12 +15,17 @@ $ ./mtls-transmitter -cert=/path/to/cert.pem -key=/path/to/key.pem -url=desired.
 ```
 
 ### Parameters
+Parameters can also be set as flags or as environment variables, with flags
+attempting to take precedence.
 
-- cert - path to the client certifiacte, required
-- key - path to the client certificate key, required
-- url - hostname to which the proxy forwards the calls, required
-- port - the port on which the proxy listens on, optional, default 8080
-- skip-ssl - if defined the proxy will skip server certificate verification, optional, default false
+| Flag | Env Var | Description |
+| --- | --- | --- |
+| `-cert` | `CERT` | The path to the client certificate; **required** |
+| `-key` | `KEY` | The path to the client certificate key; **required** |
+| `-url` | `URL` | The `hostname:port` to which the proxy fowards requests; **required** |
+| `-port` | `PORT` | The port on which the proxy listens on; default: `8080` |
+| `-skip-ssl` | `SKIP_SSL` | If set to `true`, the proxy sill skip server certificate verification; default: `false` |
+| `-silent` | `SILENT` | If set to `true`, the proxy will not log proxied events; default: `false` |
 
 ## Running inside the docker container
 
@@ -30,7 +35,7 @@ $ ./mtls-transmitter -cert=/path/to/cert.pem -key=/path/to/key.pem -url=desired.
 $ docker build -t crabtree/mtls-transmitter .
 ```
 
-### Running 
+### Running
 
 >**NOTE:** To run mtls-transmitter inside the docker container you need to provide your client certificate to your container.
 

--- a/README.md
+++ b/README.md
@@ -42,3 +42,14 @@ $ docker build -t crabtree/mtls-transmitter .
 ```bash
 $ docker run --rm -v /path/to/cert-dir:/cert -p 8080:8080 crabtree/mtls-transmitter -cert /cert/cert.pem -key /cert/key.pem -url desired.host.com
 ```
+
+## Development
+
+Use the following:
+```bash
+make          # to format and validate changes
+make build    # to build the binary
+```
+
+See the [Makefile](Makefile) for additional options.
+

--- a/cmd/transmitter/args.go
+++ b/cmd/transmitter/args.go
@@ -3,7 +3,9 @@ package main
 import (
 	"flag"
 	"fmt"
+	"log"
 	"os"
+	"strconv"
 )
 
 const (
@@ -16,22 +18,65 @@ type args struct {
 	keyPath  string
 	url      string
 	skipSSL  bool
+	silent   bool
 }
 
 func (o *args) String() string {
-	return fmt.Sprintf("-cert=%s -key=%s -url=%s -port=%d --skipSSL=%v",
-		o.certPath, o.keyPath, o.url, o.port, o.skipSSL)
+	return fmt.Sprintf("cert=%s key=%s url=%s port=%d skip-ssl=%v silent=%v",
+		o.certPath, o.keyPath, o.url, o.port, o.skipSSL, o.silent)
 }
 
 func parse() *args {
-	certPath := flag.String("cert", "", "Path to certificate file")
-	keyPath := flag.String("key", "", "Path to private key file")
-	url := flag.String("url", "", "Kyma URL")
-	port := flag.Uint("port", DefaultPort, "Port number in range 0-65535")
-	skipSSL := flag.Bool("skip-ssl", false, "Skip SSL verification")
+	certPath := flag.String("cert", "", "Path to certificate file [CERT]")
+	keyPath := flag.String("key", "", "Path to private key file [KEY]")
+	url := flag.String("url", "", "Target URL [URL]")
+	port := flag.Uint("port", DefaultPort, "Port number in range 0-65535 [PORT]")
+	skipSSL := flag.Bool("skip-ssl", false, "Skip SSL verification [SKIP_SSL=true]")
+	silent := flag.Bool("silent", false, "Do not log proxied requests [SILENT=true]")
 
 	flag.Parse()
 
+	// Check for configuration from environment.
+	// - Attempts to make flags authoritative. It gets tricky when there is a
+	//   real default set.
+	if len(*certPath) == 0 {
+		envCert := os.Getenv("CERT")
+		certPath = &envCert
+	}
+
+	if len(*keyPath) == 0 {
+		envKey := os.Getenv("KEY")
+		keyPath = &envKey
+	}
+
+	if len(*url) == 0 {
+		envUrl := os.Getenv("URL")
+		url = &envUrl
+	}
+
+	if *port != uint(DefaultPort) {
+		if envPort := os.Getenv("PORT"); len(envPort) != 0 {
+			p, e := strconv.ParseUint(envPort, 10, 32)
+			if e != nil {
+				log.Fatalf("Fatal: %v\n", e)
+			}
+			*port = uint(p)
+		}
+	}
+
+	if !*skipSSL {
+		if os.Getenv("SKIP_SSL") == "true" {
+			*skipSSL = true
+		}
+	}
+
+	if !*silent {
+		if os.Getenv("SILENT") == "true" {
+			*silent = true
+		}
+	}
+
+	// Validate required or exit.
 	if len(*certPath) == 0 {
 		printErrorAndExit("Specify path to certificate using -cert parameter")
 	}
@@ -50,10 +95,10 @@ func parse() *args {
 		port:     uint16(*port),
 		url:      *url,
 		skipSSL:  *skipSSL,
+		silent:   *silent,
 	}
 }
 
 func printErrorAndExit(err string) {
-	fmt.Fprintln(os.Stderr, err)
-	os.Exit(1)
+	log.Fatalln(err)
 }

--- a/cmd/transmitter/transmitter.go
+++ b/cmd/transmitter/transmitter.go
@@ -18,10 +18,10 @@ func main() {
 		printErrorAndExit("Error when loading cerificate, " + err.Error())
 	}
 
-	handler := proxyhandler.Create(opts.url, cert, opts.skipSSL)
+	handler := proxyhandler.Create(opts.url, cert, opts.skipSSL, opts.silent)
 
 	proxyserver.NewServer(http.DefaultServeMux, handler)
 
-	fmt.Println("mtls-transmitter is listening on port:", opts.port)
+	fmt.Printf("mtls-transmitter %v\n", opts)
 	log.Fatal(http.ListenAndServe(fmt.Sprintf(":%d", opts.port), nil))
 }

--- a/pkg/proxyhandler/proxyhandler.go
+++ b/pkg/proxyhandler/proxyhandler.go
@@ -2,12 +2,12 @@ package proxyhandler
 
 import (
 	"crypto/tls"
-	"fmt"
+	"log"
 	"net/http"
 	"net/http/httputil"
 )
 
-func Create(url string, cert tls.Certificate, skipSSL bool) http.HandlerFunc {
+func Create(url string, cert tls.Certificate, skipSSL bool, silent bool) http.HandlerFunc {
 	tlsConfig := tls.Config{
 		Certificates:       []tls.Certificate{cert},
 		InsecureSkipVerify: skipSSL,
@@ -27,7 +27,9 @@ func Create(url string, cert tls.Certificate, skipSSL bool) http.HandlerFunc {
 	}
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		fmt.Println("Proxing request to " + r.URL.String())
+		if !silent {
+			log.Printf("path=%s\n", r.URL.String())
+		}
 		proxy.ServeHTTP(w, r)
 	})
 }


### PR DESCRIPTION
Hello, this was exactly what I was looking for, so thank you!

I made a somewhat small update to support supplying configuration from the environment. Additionally, I add a Makefile, added a flag to suppress logging proxied events and changed a few things to use `log` over `fmt` for printing. In all things I believe I remained backwards compatible. Please let me know what you think. 

Cheers!
Josh